### PR TITLE
Updated map variants and excluded leagues from filtering map variants

### DIFF
--- a/src/store/domains/profile.ts
+++ b/src/store/domains/profile.ts
@@ -668,7 +668,9 @@ export class Profile {
       );
     }
 
-    prices = excludeLegacyMaps(prices);
+    if (this.activePriceLeagueId === 'Standard') {
+      prices = excludeLegacyMaps(prices);
+    }
     prices = excludeInvalidItems(prices);
 
     const customPrices = rootStore.customPriceStore.customLeaguePrices.find(

--- a/src/utils/price.utils.ts
+++ b/src/utils/price.utils.ts
@@ -186,7 +186,7 @@ export function mapApiPricedItemToPricedItem(item: IPricedItem) {
 }
 
 export function excludeLegacyMaps(prices: IExternalPrice[]) {
-  const acceptedMaps = [', Gen-19', ', Gen-20', ', Gen-21'];
+  const acceptedMaps = [', Gen-21', ', Gen-22', ', Gen-23'];
   return prices.filter((p) => p.tier === 0 || !p.variant || acceptedMaps.includes(p.variant));
 }
 


### PR DESCRIPTION
Small change to the map filtering as other variants only apply to the standard league.

Keepers example:
<img width="1325" height="358" alt="image" src="https://github.com/user-attachments/assets/a8dda072-52bf-4ad9-8f46-ca27078e8cb9" />
