### PR TITLE
[codex] Reduce startup price fetches to the active league

### DIFF
--- a/src/components/price-table/price-table-league-dropdown/PriceTableLeagueDropdownContainer.tsx
+++ b/src/components/price-table/price-table-league-dropdown/PriceTableLeagueDropdownContainer.tsx
@@ -10,7 +10,7 @@ export type PriceTableFilterForm = {
 };
 
 const PriceTableLeagueDropdownContainer = () => {
-  const { uiStateStore, leagueStore, accountStore } = useStores();
+  const { uiStateStore, leagueStore, accountStore, priceStore } = useStores();
   const { t } = useTranslation();
 
   const validationSchema = Yup.object<PriceTableFilterForm>().shape({
@@ -19,19 +19,27 @@ const PriceTableLeagueDropdownContainer = () => {
 
   const leagueId = uiStateStore!.selectedPriceTableLeagueId;
   const activeLeagueId = accountStore!.getSelectedAccount.activePriceLeague?.id;
+  const selectedLeagueId = leagueId || activeLeagueId || '';
 
   useEffect(() => {
-    if (!leagueId) {
-      uiStateStore!.setSelectedPriceTableLeagueId(activeLeagueId || '');
+    if (!selectedLeagueId) {
+      return;
     }
-  }, []);
+
+    if (leagueId !== selectedLeagueId) {
+      uiStateStore!.setSelectedPriceTableLeagueId(selectedLeagueId);
+    }
+
+    priceStore!.ensurePricesForLeague(selectedLeagueId);
+  }, [leagueId, priceStore, selectedLeagueId, uiStateStore]);
 
   const initialValues: PriceTableFilterForm = useMemo(() => {
-    return { priceLeague: leagueId || '' };
-  }, [leagueId]);
+    return { priceLeague: selectedLeagueId };
+  }, [selectedLeagueId]);
 
   const onSubmit = (form: PriceTableFilterForm) => {
     uiStateStore!.setSelectedPriceTableLeagueId(form.priceLeague);
+    priceStore!.ensurePricesForLeague(form.priceLeague);
   };
 
   return (

--- a/src/store/accountStore.ts
+++ b/src/store/accountStore.ts
@@ -36,9 +36,9 @@ export class AccountStore {
     });
 
     autorun(() => {
-      if (this.getSelectedAccount?.activeLeague) {
+      if (this.getSelectedAccount?.activePriceLeague) {
         rootStore.uiStateStore.setSelectedPriceTableLeagueId(
-          this.getSelectedAccount?.activeLeague.id
+          this.getSelectedAccount.activePriceLeague.id
         );
       }
     });
@@ -243,10 +243,13 @@ export class AccountStore {
                 leagues.concat(getCharacterLeagues(characters)).map((l) => l.id)
               );
 
-              // at initial launch, fetch prices for all leagues
-              this.rootStore.priceStore.getPricesForLeagues(
-                this.rootStore.leagueStore.priceLeagues.map((l) => l.id)
-              );
+              const initialPriceLeagueId =
+                this.getSelectedAccount.activeProfile?.activePriceLeagueId ||
+                this.rootStore.leagueStore.priceLeagues[0]?.id;
+
+              if (initialPriceLeagueId) {
+                this.rootStore.priceStore.ensurePricesForLeague(initialPriceLeagueId);
+              }
 
               return forkJoin(
                 of(account.accountLeagues).pipe(

--- a/src/store/domains/profile.ts
+++ b/src/store/domains/profile.ts
@@ -350,23 +350,8 @@ export class Profile {
 
   @action
   checkPriceStatus() {
-    // fetch prices if they are outdated
     if (this.activePriceLeagueId) {
-      const leaguePriceDetails = rootStore.priceStore.getLeaguePriceDetails(
-        this.activePriceLeagueId
-      );
-      const leaguePriceSource = rootStore.priceStore.getLeaguePriceSource(leaguePriceDetails);
-
-      const twentyMinutesAgo = moment()
-        .utc()
-        .subtract(rootStore.priceStore.pollingIntervalMinutes, 'minutes');
-      const fetchedRecently = moment(leaguePriceSource.pricedFetchedAt)
-        .utc()
-        .isAfter(twentyMinutesAgo);
-
-      if (!fetchedRecently) {
-        rootStore.priceStore.getPricesForLeagues([this.activePriceLeagueId]);
-      }
+      rootStore.priceStore.ensurePricesForLeague(this.activePriceLeagueId);
     }
   }
 

--- a/src/store/priceStore.ts
+++ b/src/store/priceStore.ts
@@ -39,19 +39,7 @@ export class PriceStore {
           const activePriceLeagueId = this.rootStore.accountStore.getSelectedAccount
             .activePriceLeague?.id;
           if (!this.rootStore.uiStateStore.isSnapshotting && activePriceLeagueId) {
-            const leaguePriceDetails = rootStore.priceStore.getLeaguePriceDetails(
-              activePriceLeagueId
-            );
-            const leaguePriceSource = rootStore.priceStore.getLeaguePriceSource(leaguePriceDetails);
-
-            const minutesAgo = moment().utc().subtract(this.pollingIntervalMinutes, 'minutes');
-            const fetchedRecently = moment(leaguePriceSource.pricedFetchedAt)
-              .utc()
-              .isAfter(minutesAgo);
-
-            if (!fetchedRecently) {
-              return of(this.getPricesForLeagues([activePriceLeagueId]));
-            }
+            this.ensurePricesForLeague(activePriceLeagueId);
           }
           return of(null);
         })
@@ -186,6 +174,26 @@ export class PriceStore {
     }
 
     return leaguePriceSource;
+  }
+
+  @action
+  ensurePricesForLeague(leagueId: string, force: boolean = false) {
+    if (!leagueId) {
+      return;
+    }
+
+    const leaguePriceDetails = this.getLeaguePriceDetails(leagueId);
+    const leaguePriceSource = this.getLeaguePriceSource(leaguePriceDetails);
+    const minutesAgo = moment().utc().subtract(this.pollingIntervalMinutes, 'minutes');
+    const fetchedRecently = leaguePriceSource.pricedFetchedAt
+      ? moment(leaguePriceSource.pricedFetchedAt).utc().isAfter(minutesAgo)
+      : false;
+
+    if (!force && leaguePriceSource.prices.length > 0 && fetchedRecently) {
+      return;
+    }
+
+    this.getPricesForLeagues([leagueId]);
   }
 
   @action


### PR DESCRIPTION
## Summary
- stop fetching Poe Ninja prices for every price league during session init
- load prices only for the active price league at startup
- fetch price data on demand when the selected price-table league changes
- keep the price-table selection aligned with the account's active price league

## Root cause
`initSession()` eagerly fetched prices for every discovered price league before the user ever viewed or switched to most of them. Accounts with many leagues could fan out into a burst of Poe Ninja requests and trigger global rate limiting (`429`), which then blocked initialization and stale price recovery.

## Validation
- traced the startup flow from `AccountStore.initSession()` into `PriceStore.getPricesForLeagues()`
- confirmed the selected price-table league was incorrectly synced to `activeLeague` instead of `activePriceLeague`
- updated all paths that need price data to reuse a single on-demand `ensurePricesForLeague()` flow

## Impact
This keeps startup traffic bounded to the league the active profile actually uses while preserving lazy loading for manual price-league changes in the price table.