### PR TITLE
Fix unique price matching resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+#### Fixed
+- Improved unique item variant/link matching so unlinked uniques and variant-specific uniques are less likely to disappear from snapshots.
+- Made poe.ninja price category refreshes tolerate one missing or failing category without discarding all other prices.
+
 ## [1.2.11] - 2025-02-21
 #### Added
 - Added support for Beasts, new Map Variants & Kaluuran Runes (thank you Mrjamy <3)

--- a/src/services/poe-ninja.service.ts
+++ b/src/services/poe-ninja.service.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
-import { forkJoin, from } from 'rxjs';
+import { forkJoin, from, of } from 'rxjs';
 import RateLimiter from 'rxjs-ratelimiter';
-import { map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { IExternalPrice } from '../interfaces/external-price.interface';
 import { IPoeNinjaItemOverview } from '../interfaces/poe-ninja/poe-ninja-item-overview.interface';
 import {
@@ -94,7 +94,8 @@ function getItemPrices(league: string) {
           } else {
             return []; // no prices found on ninja
           }
-        })
+        }),
+        catchError(() => of([] as IExternalPrice[]))
       );
     })
   ).pipe(map((arrays) => arrays.reduce((acc, array) => [...acc, ...array], [])));
@@ -120,7 +121,8 @@ function getCurrencyPrices(league: string) {
           } else {
             return []; // no prices found on ninja
           }
-        })
+        }),
+        catchError(() => of([] as IExternalPrice[]))
       );
     })
   ).pipe(map((arrays) => arrays.reduce((acc, array) => [...acc, ...array], [])));

--- a/src/services/pricing.service.ts
+++ b/src/services/pricing.service.ts
@@ -1,6 +1,7 @@
 import { IExternalPrice } from '../interfaces/external-price.interface';
 import { IPricedItem } from '../interfaces/priced-item.interface';
 import { isSpecialGem } from '../utils/item.utils';
+import { pickBestUniquePrice } from '../utils/price-match.utils';
 import { mapPriceToItem } from '../utils/price.utils';
 
 export const pricingService = {
@@ -41,25 +42,7 @@ function priceItem(item: IPricedItem, prices: IExternalPrice[]) {
         break;
       case 3: {
         // unique
-        const itemPrices = prices.filter(
-          (p) =>
-            p.name === item.name &&
-            ((item.links < 5 && p.links !== undefined && p.links < 5) || p.links === item.links) &&
-            p.frameType === 3 &&
-            (p.variant === item.variant ||
-              p.variant === undefined ||
-              p.variant === '' ||
-              p.variant === null)
-        );
-
-        const qualityPrices = itemPrices.filter((ip) => !ip.quality || ip.quality === item.quality);
-
-        if (qualityPrices.length === 1) {
-          price = qualityPrices[0];
-        } else {
-          matchedPrices = itemPrices.filter((ip) => ip.quality === 0);
-        }
-
+        price = pickBestUniquePrice(item, prices);
         break;
       }
       case 4: {
@@ -91,8 +74,8 @@ function priceItem(item: IPricedItem, prices: IExternalPrice[]) {
           const allMatchedPrices = prices
             .filter((p) => p.name === item.name)
             .sort((a, b) => a.ilvl! - b.ilvl!);
-          if (allMatchedPrices.length >= 0) {
-            matchedPrices = [allMatchedPrices.pop()];
+          if (allMatchedPrices.length > 0) {
+            matchedPrices = [allMatchedPrices.pop()!];
           }
         } else {
           matchedPrices = prices.filter((p) => p.name === item.name);
@@ -123,8 +106,8 @@ function priceItem(item: IPricedItem, prices: IExternalPrice[]) {
         const allMatchedPrices = prices
           .filter((p) => p.name === item.name && p.ilvl !== undefined && p.ilvl <= item.ilvl)
           .sort((a, b) => a.ilvl! - b.ilvl!);
-        if (allMatchedPrices.length >= 0) {
-          matchedPrices = [allMatchedPrices.pop()];
+        if (allMatchedPrices.length > 0) {
+          matchedPrices = [allMatchedPrices.pop()!];
         }
         break;
       }

--- a/src/utils/item.utils.test.ts
+++ b/src/utils/item.utils.test.ts
@@ -1,0 +1,70 @@
+import { IItem } from '../interfaces/item.interface';
+import { getItemVariant, mapItemsToPricedItems } from './item.utils';
+
+const createItem = (overrides: Partial<IItem>): IItem => ({
+  id: 'item-1',
+  verified: true,
+  w: 1,
+  h: 1,
+  ilvl: 1,
+  icon: 'icon.png',
+  league: 'Standard',
+  sockets: [],
+  name: '',
+  shaper: false,
+  elder: false,
+  baseType: '',
+  fractured: false,
+  synthesised: false,
+  typeLine: '',
+  identified: true,
+  corrupted: false,
+  lockedToCharacter: false,
+  requirements: [],
+  implicitMods: [],
+  explicitMods: [],
+  fracturedMods: [],
+  frameType: 0,
+  x: 0,
+  y: 0,
+  inventoryId: 'Stash1',
+  socketedItems: [],
+  properties: [],
+  flavourText: [],
+  craftedMods: [],
+  enchantMods: [],
+  utilityMods: [],
+  descrText: '',
+  prophecyText: '',
+  socket: 0,
+  ...overrides,
+});
+
+describe('getItemVariant', () => {
+  it('detects Voices passive-count variants from item mods', () => {
+    expect(getItemVariant([], ['Adds 3 Passive Skills'], 'Voices')).toBe('3 Passives');
+  });
+
+  it("detects Yriel's Fostering beast variants from item mods", () => {
+    expect(
+      getItemVariant([], ['Grants Level 20 Summon Bestial Rhoa Skill'], "Yriel's Fostering")
+    ).toBe('Rhoa');
+  });
+
+  it('does not treat every Impresence as the lightning variant', () => {
+    expect(getItemVariant([], ['Adds Fire Damage'], 'Impresence')).toBe('Fire');
+  });
+});
+
+describe('mapItemsToPricedItems', () => {
+  it('passes the normalized unique name into variant detection', () => {
+    const item = createItem({
+      name: 'Voices',
+      typeLine: 'Large Cluster Jewel',
+      frameType: 3,
+      explicitMods: ['Adds 5 Passive Skills'],
+    });
+
+    expect(mapItemsToPricedItems([item])[0].variant).toBe('5 Passives');
+  });
+});

--- a/src/utils/item.utils.ts
+++ b/src/utils/item.utils.ts
@@ -95,11 +95,7 @@ export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
         item.properties !== null && item.properties !== undefined ? getLevel(item.properties) : 0,
       stackSize: item.stackSize || 1,
       totalStacksize: item.maxStackSize || 1,
-      variant: getItemVariant(
-        item.sockets,
-        item.explicitMods,
-        getItemName(item.name, item.typeLine)
-      ),
+      variant: getItemVariant(item.sockets, item.explicitMods, name),
       tab: tab
         ? [
             {
@@ -235,55 +231,69 @@ export function isShaperMap(implicitMods: string[]): boolean {
   return false;
 }
 
-export function getItemVariant(sockets: ISocket[], explicitMods: string[], name: string): string {
-  if (explicitMods) {
-    const watchStoneUsesMod = explicitMods.find((em) => em.includes('uses remaining'));
-    if (watchStoneUsesMod) {
-      return watchStoneUsesMod.split(' ')[0];
+export function getItemVariant(
+  sockets: ISocket[] | undefined,
+  explicitMods: string[] | undefined,
+  name: string
+): string {
+  const mods = explicitMods ?? [];
+  const itemSockets = sockets ?? [];
+
+  const watchStoneUsesMod = mods.find((em) => em.includes('uses remaining'));
+  if (watchStoneUsesMod) {
+    return watchStoneUsesMod.split(' ')[0];
+  }
+
+  if (name === 'Voices') {
+    const passiveMod = mods.find((em) => em.includes('Adds') && em.includes('Passive Skill'));
+    const passiveCount = passiveMod?.match(/Adds (\d+) Passive Skills?/);
+    if (passiveCount) {
+      return `${passiveCount[1]} Passive${passiveCount[1] === '1' ? '' : 's'}`;
+    }
+  }
+
+  if (name === "Yriel's Fostering") {
+    if (mods.some((s) => s.includes('Bestial Rhoa'))) {
+      return 'Rhoa';
+    }
+    if (mods.some((s) => s.includes('Bestial Ursa'))) {
+      return 'Ursa';
+    }
+    if (mods.some((s) => s.includes('Bestial Snake'))) {
+      return 'Snake';
     }
   }
 
   if (name === 'Impresence') {
-    if (explicitMods.filter((s) => s.includes('Lightning Damage'))) {
+    if (mods.some((s) => s.includes('Lightning Damage'))) {
       return 'Lightning';
     }
-    if (explicitMods.filter((s) => s.includes('Fire Damage'))) {
+    if (mods.some((s) => s.includes('Fire Damage'))) {
       return 'Fire';
     }
-    if (explicitMods.filter((s) => s.includes('Cold Damage'))) {
+    if (mods.some((s) => s.includes('Cold Damage'))) {
       return 'Cold';
     }
-    if (explicitMods.filter((s) => s.includes('Physical Damage'))) {
+    if (mods.some((s) => s.includes('Physical Damage'))) {
       return 'Physical';
     }
-    if (explicitMods.filter((s) => s.includes('Chaos Damage'))) {
+    if (mods.some((s) => s.includes('Chaos Damage'))) {
       return 'Chaos';
     }
   }
 
-  // Abyssal
-  if (name === 'Lightpoacher') {
-    const count = sockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
-    return count === 1 ? count + ' Jewel' : count + ' Jewels';
-  }
-  if (name === 'Shroud of the Lightless') {
-    const count = sockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
-    return count === 1 ? count + ' Jewel' : count + ' Jewels';
-  }
-  if (name === 'Bubonic Trail') {
-    const count = sockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
-    return count === 1 ? count + ' Jewel' : count + ' Jewels';
-  }
-  if (name === 'Tombfist') {
-    const count = sockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
-    return count === 1 ? count + ' Jewel' : count + ' Jewels';
-  }
-  if (name === 'Hale Negator') {
-    const count = sockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
-    return count === 1 ? count + ' Jewel' : count + ' Jewels';
-  }
-  if (name === 'Command of the Pit') {
-    const count = sockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
+  // Abyssal uniques are listed by abyssal socket count on poe.ninja.
+  if (
+    [
+      'Lightpoacher',
+      'Shroud of the Lightless',
+      'Bubonic Trail',
+      'Tombfist',
+      'Hale Negator',
+      'Command of the Pit',
+    ].includes(name)
+  ) {
+    const count = itemSockets.filter((x) => x.sColour === 'A' || x.sColour === 'a').length;
     return count === 1 ? count + ' Jewel' : count + ' Jewels';
   }
 

--- a/src/utils/price-match.utils.test.ts
+++ b/src/utils/price-match.utils.test.ts
@@ -1,0 +1,72 @@
+import { IExternalPrice } from '../interfaces/external-price.interface';
+import { IPricedItem } from '../interfaces/priced-item.interface';
+import { isUniqueLinkMatch, isVariantMatch, pickBestUniquePrice } from './price-match.utils';
+
+const pricedItem = (overrides: Partial<IPricedItem> = {}): IPricedItem => ({
+  uuid: 'priced-item-1',
+  name: 'The Ivory Tower',
+  itemId: 'item-1',
+  typeLine: "Saint's Hauberk",
+  frameType: 3,
+  total: 0,
+  calculated: 0,
+  max: 0,
+  elder: false,
+  shaper: false,
+  blighted: false,
+  coffin: false,
+  beast: false,
+  mean: 0,
+  median: 0,
+  min: 0,
+  mode: 0,
+  ilvl: 0,
+  stackSize: 1,
+  totalStacksize: 1,
+  links: 0,
+  quality: 0,
+  level: 0,
+  corrupted: false,
+  icon: 'item-icon.png',
+  sockets: 0,
+  variant: '',
+  tier: 0,
+  inventoryId: 'Stash1',
+  tab: [],
+  ...overrides,
+});
+
+const externalPrice = (overrides: Partial<IExternalPrice> = {}): IExternalPrice => ({
+  name: 'The Ivory Tower',
+  icon: 'price-icon.png',
+  count: 25,
+  calculated: 10,
+  frameType: 3,
+  ...overrides,
+});
+
+describe('unique price matching', () => {
+  it('treats missing poe.ninja links as unlinked for unique items', () => {
+    expect(isUniqueLinkMatch(0, undefined)).toBe(true);
+    expect(isUniqueLinkMatch(6, undefined)).toBe(false);
+  });
+
+  it('matches singular and plural passive-count variants', () => {
+    expect(isVariantMatch('3 Passives', '3 Passive')).toBe(true);
+  });
+
+  it('prices unlinked uniques when poe.ninja omits the links field', () => {
+    const price = pickBestUniquePrice(pricedItem(), [externalPrice()]);
+
+    expect(price?.calculated).toBe(10);
+  });
+
+  it('selects exact variant prices when multiple variant rows exist', () => {
+    const price = pickBestUniquePrice(pricedItem({ name: 'Voices', variant: '3 Passives' }), [
+      externalPrice({ name: 'Voices', variant: '1 Passive', calculated: 100 }),
+      externalPrice({ name: 'Voices', variant: '3 Passive', calculated: 50 }),
+    ]);
+
+    expect(price?.calculated).toBe(50);
+  });
+});

--- a/src/utils/price-match.utils.ts
+++ b/src/utils/price-match.utils.ts
@@ -1,0 +1,60 @@
+import { IExternalPrice } from '../interfaces/external-price.interface';
+import { IPricedItem } from '../interfaces/priced-item.interface';
+
+const normalizeVariant = (variant?: string) =>
+  (variant ?? '')
+    .toLowerCase()
+    .replace(/passives/g, 'passive')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export const isVariantMatch = (itemVariant?: string, priceVariant?: string) => {
+  const normalizedItemVariant = normalizeVariant(itemVariant);
+  const normalizedPriceVariant = normalizeVariant(priceVariant);
+
+  return (
+    normalizedItemVariant === normalizedPriceVariant ||
+    normalizedItemVariant === '' ||
+    normalizedPriceVariant === ''
+  );
+};
+
+export const isUniqueLinkMatch = (itemLinks: number, priceLinks?: number) => {
+  const normalizedPriceLinks = priceLinks ?? 0;
+  return itemLinks < 5 ? normalizedPriceLinks < 5 : normalizedPriceLinks === itemLinks;
+};
+
+export const filterUniquePriceCandidates = (item: IPricedItem, prices: IExternalPrice[]) =>
+  prices.filter(
+    (price) =>
+      price.name === item.name &&
+      isUniqueLinkMatch(item.links, price.links) &&
+      price.frameType === 3 &&
+      isVariantMatch(item.variant, price.variant)
+  );
+
+export const pickBestUniquePrice = (
+  item: IPricedItem,
+  prices: IExternalPrice[]
+): IExternalPrice | undefined => {
+  const itemPrices = filterUniquePriceCandidates(item, prices);
+  const qualityPrices = itemPrices.filter((ip) => !ip.quality || ip.quality === item.quality);
+
+  if (qualityPrices.length === 1) {
+    return qualityPrices[0];
+  }
+
+  const exactVariantPrices = qualityPrices.filter(
+    (ip) => normalizeVariant(ip.variant) === normalizeVariant(item.variant)
+  );
+  if (exactVariantPrices.length === 1) {
+    return exactVariantPrices[0];
+  }
+
+  const unqualifiedPrices = itemPrices.filter((ip) => !ip.quality || ip.quality === 0);
+  if (unqualifiedPrices.length === 1) {
+    return unqualifiedPrices[0];
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
﻿## Summary
- add typed unique-price matching helpers for unlinked uniques and variant-specific uniques
- detect `Voices` passive-count variants and `Yriel's Fostering` beast variants from raw item mods
- make poe.ninja price category fetches tolerate one failing category without discarding all other price data
- add focused regression tests for the new matching behavior

## Root Cause
Some PoE item/price rows are not stable across leagues or poe.ninja categories: unlinked uniques can arrive with missing/zero link metadata, several uniques rely on variant strings, and one failing poe.ninja category could previously fail an entire price refresh. A couple of variant detectors were also brittle: `mapItemsToPricedItems` passed the raw `name + typeLine` into variant detection, and Impresence variant checks used truthy arrays.

## Fix
- Centralized unique link/variant matching in `price-match.utils.ts`.
- Passed the normalized item name into variant detection.
- Added explicit variant extraction for `Voices` and `Yriel's Fostering`.
- Fixed the empty-price-list guard for coffins/embers so an empty match list does not produce `[undefined]`.
- Let individual poe.ninja category requests fall back to an empty category result while keeping successful categories.

## Validation
- `npm.cmd ci --no-audit --no-fund` passed.
- `$env:CI='true'; npx.cmd -y -p node@14 -p npm@7 npm run react-test -- --watchAll=false src/utils/item.utils.test.ts src/utils/price-match.utils.test.ts` passed: 2 suites, 8 tests.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- eslint src/services/poe-ninja.service.ts src/services/pricing.service.ts src/utils/item.utils.ts src/utils/item.utils.test.ts src/utils/price-match.utils.ts src/utils/price-match.utils.test.ts` passed with the repo's existing React-version warning.
- `npx.cmd -y -p node@14 -p npm@7 npm run react-build` passed.

## Risk / Rollback
Low-to-moderate risk. This changes matching for unique items and price-category failures only. If a regression appears, revert this PR to restore the previous exact-match behavior.

Refs #12
Refs #30
Refs #38
Refs #43
