### PR TITLE
Contain rate-limit retry loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+#### Fixed
+- Prevented expired `Retry-After` cooldowns and repeated session failures from leaving snapshot/session retry loops stuck or duplicated.
+
 ## [1.2.11] - 2025-02-21
 #### Added
 - Added support for Beasts, new Map Variants & Kaluuran Runes (thank you Mrjamy <3)

--- a/src/store/accountStore.ts
+++ b/src/store/accountStore.ts
@@ -28,6 +28,7 @@ export class AccountStore {
   @observable authState: string = uuidv4();
 
   cancelledRetry: Subject<boolean> = new Subject();
+  initSessionRetryQueued: boolean = false;
 
   constructor(private rootStore: RootStore) {
     makeObservable(this);
@@ -66,6 +67,7 @@ export class AccountStore {
 
   @action
   cancelRetries() {
+    this.initSessionRetryQueued = false;
     this.cancelledRetry.next(true);
   }
 
@@ -310,6 +312,7 @@ export class AccountStore {
 
   @action
   initSessionSuccess() {
+    this.initSessionRetryQueued = false;
     this.rootStore.uiStateStore.resetStatusMessage();
     this.rootStore.notificationStore.createNotification('init_session', 'success');
     this.rootStore.uiStateStore.setIsInitiating(false);
@@ -322,10 +325,14 @@ export class AccountStore {
 
   @action
   initSessionFail(e: AxiosError | Error) {
-    if (this.rootStore.routeStore.redirectedTo !== '/login') {
+    if (this.rootStore.routeStore.redirectedTo !== '/login' && !this.initSessionRetryQueued) {
+      this.initSessionRetryQueued = true;
       fromStream(
         timer(45 * 1000).pipe(
-          switchMap(() => of(this.initSession())),
+          switchMap(() => {
+            this.initSessionRetryQueued = false;
+            return of(this.initSession());
+          }),
           takeUntil(this.cancelledRetry)
         )
       );

--- a/src/store/domains/account.ts
+++ b/src/store/domains/account.ts
@@ -28,6 +28,7 @@ export class Account implements IAccount {
   @persist('list', Profile) @observable profiles: Profile[] = [new Profile({ name: 'profile 1' })];
 
   cancelled: Subject<boolean> = new Subject();
+  snapshotQueued: boolean = false;
 
   constructor(obj?: IAccount) {
     makeObservable(this);
@@ -86,9 +87,14 @@ export class Account implements IAccount {
 
   @action
   queueSnapshot(milliseconds?: number) {
+    if (this.snapshotQueued) {
+      return;
+    }
+    this.snapshotQueued = true;
     fromStream(
       timer(milliseconds ? milliseconds : rootStore.settingStore.autoSnapshotInterval).pipe(
         map(() => {
+          this.snapshotQueued = false;
           if (this.activeProfile && this.activeProfile.readyToSnapshot) {
             this.activeProfile.snapshot();
           } else {
@@ -103,6 +109,7 @@ export class Account implements IAccount {
 
   @action
   dequeueSnapshot() {
+    this.snapshotQueued = false;
     this.cancelled.next(true);
   }
 

--- a/src/store/domains/profile.ts
+++ b/src/store/domains/profile.ts
@@ -84,7 +84,7 @@ export class Profile {
       rootStore.uiStateStore.initiated &&
       !rootStore.uiStateStore.isSnapshotting &&
       this.hasPricesForActiveLeague &&
-      rootStore.rateLimitStore.retryAfter === 0
+      !rootStore.rateLimitStore.isRetryAfterActive()
     );
   }
 

--- a/src/store/rateLimitStore.test.ts
+++ b/src/store/rateLimitStore.test.ts
@@ -1,0 +1,24 @@
+import { RateLimitStore } from './rateLimitStore';
+import { RootStore } from './rootStore';
+
+describe('RateLimitStore retry-after handling', () => {
+  it('stores retry-after as an expiring timestamp', () => {
+    const store = new RateLimitStore({} as RootStore);
+
+    store.setRetryAfter(2);
+
+    expect(store.isRetryAfterActive()).toBe(true);
+    expect(store.getRetryAfterMillisecondsRemaining()).toBeGreaterThan(0);
+    expect(store.getRetryAfterMillisecondsRemaining()).toBeLessThanOrEqual(2000);
+  });
+
+  it('clears non-positive retry-after values', () => {
+    const store = new RateLimitStore({} as RootStore);
+
+    store.setRetryAfter(2);
+    store.setRetryAfter(0);
+
+    expect(store.isRetryAfterActive()).toBe(false);
+    expect(store.getRetryAfterMillisecondsRemaining()).toBe(0);
+  });
+});

--- a/src/store/rateLimitStore.ts
+++ b/src/store/rateLimitStore.ts
@@ -46,7 +46,15 @@ export class RateLimitStore {
 
   @action
   setRetryAfter(seconds: number) {
-    this.retryAfter = seconds === 0 ? 0 : new Date().setSeconds(new Date().getSeconds() + seconds);
+    this.retryAfter = seconds > 0 ? Date.now() + seconds * 1000 : 0;
+  }
+
+  getRetryAfterMillisecondsRemaining() {
+    return Math.max(this.retryAfter - Date.now(), 0);
+  }
+
+  isRetryAfterActive() {
+    return this.getRetryAfterMillisecondsRemaining() > 0;
   }
 
   @action


### PR DESCRIPTION
﻿## Summary
- make `Retry-After` cooldowns expire based on their timestamp instead of blocking snapshots until restart
- prevent duplicate queued auto-snapshot timers on repeated queue calls
- prevent repeated session failures from scheduling overlapping 45-second init retries
- add focused retry-after regression tests

## Root Cause
`retryAfter` was stored as a future timestamp but readiness checked for strict equality with zero, so a rate-limit response could leave snapshotting blocked after the cooldown elapsed. Repeated queue/retry calls could also stack timers during unstable API or connection periods.

## Fix
- Added `RateLimitStore` helpers for remaining retry-after time and active cooldown detection.
- Updated snapshot readiness to use the expiring cooldown check.
- Added small guard flags for queued auto-snapshots and init-session retry timers.

## Validation
- `$env:CI='true'; npx.cmd -y -p node@14 -p npm@7 npm run react-test -- --watchAll=false src/store/rateLimitStore.test.ts` passed: 1 suite, 2 tests.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- eslint src/store/rateLimitStore.ts src/store/rateLimitStore.test.ts src/store/accountStore.ts src/store/domains/account.ts src/store/domains/profile.ts` passed with the repo's existing React-version warning.
- `npx.cmd -y -p node@14 -p npm@7 npm run react-build` passed.

## Risk / Rollback
Low risk. The changes only affect cooldown/retry scheduling after rate-limit or session-init failure paths. Revert this PR to restore the previous retry behavior.

Refs #7
Refs #19
Refs #35
