### PR TITLE
Preserve character item locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+#### Fixed
+- Preserved character inventory/equipment snapshot identity and item location fields for exports.
+
 ## [1.2.11] - 2025-02-21
 #### Added
 - Added support for Beasts, new Map Variants & Kaluuran Runes (thank you Mrjamy <3)

--- a/src/interfaces/priced-item.interface.ts
+++ b/src/interfaces/priced-item.interface.ts
@@ -30,6 +30,13 @@ export interface IPricedItem {
   variant: string;
   tier: number;
   inventoryId: string;
+  x?: number;
+  y?: number;
+  source?: string;
+  tabId?: string;
+  tabName?: string;
+  tabIndex?: number;
+  tabColor?: string;
   tab: ICompactTab[];
   detailsUrl?: string;
 }

--- a/src/store/domains/profile.ts
+++ b/src/store/domains/profile.ts
@@ -579,12 +579,16 @@ export class Profile {
             let includedCharacterItems: IPricedItem[] = [];
             if (this.includeInventory) {
               const inventory = characterWithItems?.data?.character.inventory;
-              const mappedInventory = inventory ? mapItemsToPricedItems(inventory) : [];
+              const mappedInventory = inventory
+                ? mapItemsToPricedItems(inventory, undefined, 'Character inventory')
+                : [];
               includedCharacterItems = includedCharacterItems.concat(mappedInventory);
             }
             if (this.includeEquipment) {
               const equipment = characterWithItems?.data?.character.equipment;
-              const mappedEquipment = equipment ? mapItemsToPricedItems(equipment) : [];
+              const mappedEquipment = equipment
+                ? mapItemsToPricedItems(equipment, undefined, 'Character equipment')
+                : [];
               includedCharacterItems = includedCharacterItems.concat(mappedEquipment);
             }
             const characterTab: IStashTabSnapshot = {

--- a/src/utils/item-location.utils.test.ts
+++ b/src/utils/item-location.utils.test.ts
@@ -1,0 +1,77 @@
+import { IItem } from '../interfaces/item.interface';
+import { IStashTab } from '../interfaces/stash.interface';
+import { mapItemsToPricedItems } from './item.utils';
+
+const createItem = (overrides: Partial<IItem>): IItem => ({
+  id: 'item-1',
+  verified: true,
+  w: 1,
+  h: 1,
+  ilvl: 1,
+  icon: 'icon.png',
+  league: 'Standard',
+  sockets: [],
+  name: '',
+  shaper: false,
+  elder: false,
+  baseType: '',
+  fractured: false,
+  synthesised: false,
+  typeLine: 'Chaos Orb',
+  identified: true,
+  corrupted: false,
+  lockedToCharacter: false,
+  requirements: [],
+  implicitMods: [],
+  explicitMods: [],
+  fracturedMods: [],
+  frameType: 5,
+  x: 3,
+  y: 7,
+  inventoryId: 'Stash1',
+  socketedItems: [],
+  properties: [],
+  flavourText: [],
+  craftedMods: [],
+  enchantMods: [],
+  utilityMods: [],
+  descrText: '',
+  prophecyText: '',
+  socket: 0,
+  ...overrides,
+});
+
+const stashTab: IStashTab = {
+  id: 'stash-tab-1',
+  index: 2,
+  name: 'Dump',
+  type: 'NormalStash',
+  metadata: { colour: '#123456' },
+};
+
+describe('mapItemsToPricedItems location fields', () => {
+  it('preserves stash tab and grid location data for exports', () => {
+    const item = mapItemsToPricedItems([createItem({ id: 'currency-1' })], stashTab)[0];
+
+    expect(item.itemId).toBe('currency-1');
+    expect(item.x).toBe(3);
+    expect(item.y).toBe(7);
+    expect(item.tabId).toBe('stash-tab-1');
+    expect(item.tabName).toBe('Dump');
+    expect(item.tabIndex).toBe(2);
+    expect(item.tabColor).toBe('#123456');
+  });
+
+  it('marks character inventory and equipment sources without requiring a stash tab', () => {
+    const item = mapItemsToPricedItems(
+      [createItem({ inventoryId: 'BodyArmour', x: 0, y: 0 })],
+      undefined,
+      'Character equipment'
+    )[0];
+
+    expect(item.source).toBe('Character equipment');
+    expect(item.inventoryId).toBe('BodyArmour');
+    expect(item.x).toBe(0);
+    expect(item.y).toBe(0);
+  });
+});

--- a/src/utils/item.utils.ts
+++ b/src/utils/item.utils.ts
@@ -48,7 +48,7 @@ export function parseTabNames(tabs: ICompactTab[]) {
   return tabs.map((t) => t.name).join(', ');
 }
 
-export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
+export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab, source?: string) {
   return items.map((item: IItem) => {
     const mapTier =
       item.properties !== null && item.properties !== undefined ? getMapTier(item.properties) : 0;
@@ -72,6 +72,13 @@ export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
       frameType: item.frameType,
       calculated: 0,
       inventoryId: item.inventoryId,
+      x: item.x,
+      y: item.y,
+      source: source ?? (tab ? 'Stash tab' : item.inventoryId),
+      tabId: tab?.id,
+      tabName: tab?.name,
+      tabIndex: tab?.index,
+      tabColor: tab?.metadata.colour,
       elder: (item.elder !== undefined ? item.elder : false) || isElderMap(item.implicitMods),
       shaper: (item.shaper !== undefined ? item.shaper : false) || isShaperMap(item.implicitMods),
       blighted: blighted,

--- a/src/utils/snapshot-location.utils.test.ts
+++ b/src/utils/snapshot-location.utils.test.ts
@@ -1,0 +1,27 @@
+jest.mock('..', () => ({
+  rootStore: {},
+}));
+
+import { IStashTabSnapshot } from '../interfaces/stash-tab-snapshot.interface';
+import { Snapshot } from '../store/domains/snapshot';
+import { mapSnapshotToApiSnapshot } from './snapshot.utils';
+
+describe('mapSnapshotToApiSnapshot location mapping', () => {
+  it('preserves synthetic character snapshots when no stash tab metadata exists', () => {
+    const snapshot = new Snapshot({
+      stashTabSnapshots: [
+        {
+          stashTabId: 'Character',
+          value: 42,
+          pricedItems: [],
+        } as IStashTabSnapshot,
+      ],
+    });
+
+    const apiSnapshot = mapSnapshotToApiSnapshot(snapshot, []);
+
+    expect(apiSnapshot.stashTabs[0].stashTabId).toBe('Character');
+    expect(apiSnapshot.stashTabs[0].name).toBe('Character');
+    expect(apiSnapshot.stashTabs[0].value).toBe(42);
+  });
+});

--- a/src/utils/snapshot.utils.ts
+++ b/src/utils/snapshot.utils.ts
@@ -21,12 +21,12 @@ export const mapSnapshotToApiSnapshot = (snapshot: Snapshot, stashTabs?: IStashT
           const foundTab = filteredLeagueTabs?.find((lt) => lt.id === st.stashTabId);
           return {
             uuid: st.uuid,
-            stashTabId: foundTab?.id,
+            stashTabId: foundTab?.id ?? st.stashTabId,
             pricedItems: st.pricedItems,
             index: foundTab?.index,
             value: st.value,
             color: foundTab ? foundTab.metadata.colour : undefined,
-            name: foundTab?.name,
+            name: foundTab?.name ?? st.stashTabId,
           } as IApiStashTabSnapshot;
         })
       : snapshot.stashTabSnapshots,


### PR DESCRIPTION
﻿## Summary
- preserve character inventory/equipment snapshot identity when snapshots are mapped with stash-tab metadata
- attach item location fields for stash and character items so exports include raw item id, inventory id, x/y, source, and tab metadata
- add focused regression tests for item location mapping and synthetic character snapshots

## Root Cause
Character inventory/equipment items were mapped into a synthetic `Character` snapshot, but `mapSnapshotToApiSnapshot` replaced unknown stash-tab ids with `undefined` when stash metadata was provided. Export rows also did not carry the raw grid/source metadata that is already available from the PoE item payload.

## Fix
- Fall back to the snapshot's own `stashTabId` and name when a snapshot is not backed by a stash tab.
- Preserve x/y, source, and tab metadata in `IPricedItem` rows produced from raw PoE items.
- Mark character inventory and equipment items with explicit source labels.

## Validation
- `$env:CI='true'; npx.cmd -y -p node@14 -p npm@7 npm run react-test -- --watchAll=false src/utils/item-location.utils.test.ts src/utils/snapshot-location.utils.test.ts` passed: 2 suites, 3 tests.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- eslint src/interfaces/priced-item.interface.ts src/utils/item.utils.ts src/utils/snapshot.utils.ts src/store/domains/profile.ts src/utils/item-location.utils.test.ts src/utils/snapshot-location.utils.test.ts` passed with the repo's existing React-version warning.
- `npx.cmd -y -p node@14 -p npm@7 npm run react-build` passed.

## Risk / Rollback
Low risk. This preserves additional metadata and fixes a fallback id/name path; it does not change pricing math. Revert this PR if exported rows or character snapshot metadata need to return to the previous shape.

Refs #20
Refs #22
