### PR TITLE
Remove analytics and validate auth state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+#### Fixed
+- Removed Google Analytics page/action tracking, scrubbed auth secrets from Sentry events, and validated OAuth callback state before exchanging authorization codes.
+
 ## [1.2.11] - 2025-02-21
 #### Added
 - Added support for Beasts, new Map Variants & Kaluuran Runes (thank you Mrjamy <3)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as isDev from 'electron-is-dev';
 import * as sentry from '@sentry/electron';
 import * as windowStateKeeper from 'electron-window-state';
+import { getAuthCallbackPayload } from '../src/utils/auth-callback.utils';
+import { sanitizeSentryEvent } from '../src/utils/sentry.utils';
 
 import {
   createFlashFrame,
@@ -32,6 +34,7 @@ import { SYSTEMS } from './enums';
 if (!isDev) {
   sentry.init({
     dsn: 'https://cefd9ca960954f39870e162aa8936535@o222604.ingest.sentry.io/6011593',
+    beforeSend: sanitizeSentryEvent,
     ignoreErrors: [
       'Request failed',
       'net::',
@@ -51,7 +54,7 @@ if (!isDev) {
 const gotTheLock = app.requestSingleInstanceLock();
 let isQuitting: boolean;
 let updateAvailable: boolean;
-let deeplinkingUrl: any;
+let deeplinkingUrl: string | string[];
 let trayProps: CreateTrayProps;
 
 /**
@@ -235,10 +238,10 @@ if (!gotTheLock) {
       if (process.platform !== SYSTEMS.MACOS) {
         // Keep only command line / deep linked arguments
         deeplinkingUrl = argv.slice(1);
-        const raw_code = /code=([^&]*)/.exec(deeplinkingUrl) || null;
-        const code = raw_code && raw_code.length > 1 ? raw_code[1] : null;
-        const error = /\?error=(.+)$/.exec(deeplinkingUrl);
-        browserWindows[MAIN_BROWSER_WINDOW].webContents.send('auth-callback', { code, error });
+        browserWindows[MAIN_BROWSER_WINDOW].webContents.send(
+          'auth-callback',
+          getAuthCallbackPayload(deeplinkingUrl)
+        );
       }
 
       if (browserWindows[MAIN_BROWSER_WINDOW].isMinimized()) {
@@ -266,10 +269,10 @@ if (!gotTheLock) {
   app.on('open-url', function (event, data) {
     event.preventDefault();
     deeplinkingUrl = data;
-    const raw_code = /code=([^&]*)/.exec(deeplinkingUrl) || null;
-    const code = raw_code && raw_code.length > 1 ? raw_code[1] : null;
-    const error = /\?error=(.+)$/.exec(deeplinkingUrl);
-    browserWindows[MAIN_BROWSER_WINDOW].webContents.send('auth-callback', { code, error });
+    browserWindows[MAIN_BROWSER_WINDOW].webContents.send(
+      'auth-callback',
+      getAuthCallbackPayload(deeplinkingUrl)
+    );
   });
 
   app.on('before-quit', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3421,11 +3421,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
-    "@types/universal-analytics": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.4.tgz",
-      "integrity": "sha512-9g3F0SGxVr4UDd6y07bWtFnkpSSX1Ake7U7AGHgSFrwM6pF53/fV85bfxT2JLWS/3sjLCcyzoYzQlCxpkVo7wA=="
-    },
     "@types/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
@@ -18958,23 +18953,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
       "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
-    },
-    "universal-analytics": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.23.tgz",
-      "integrity": "sha512-lgMIH7XBI6OgYn1woDEmxhGdj8yDefMKg7GkWdeATAlQZFrMrNyxSkpDzY57iY0/6fdlzTbBV03OawvvzG+q7A==",
-      "requires": {
-        "debug": "^4.1.1",
-        "request": "^2.88.2",
-        "uuid": "^3.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@sentry/react": "^6.13.3",
     "@types/react": "^17.0.26",
     "@types/reactour": "^1.13.1",
-    "@types/universal-analytics": "^0.4.3",
     "axios": "^0.21.1",
     "axios-observable": "^1.1.2",
     "cli-truncate": "^3.1.0",
@@ -61,7 +60,6 @@
     "tslib": "^2.0.3",
     "typeface-roboto": "1.1.13",
     "typescript": "^4.0.3",
-    "universal-analytics": "^0.4.20",
     "uuid": "^8.3.1",
     "victory": "^36.0.1",
     "yup": "^0.29.3"

--- a/src/config/app.config.dev.ts
+++ b/src/config/app.config.dev.ts
@@ -2,7 +2,6 @@ const devConfig = {
   baseUrl: 'https://api.exilence.de',
   production: false,
   sentryBrowserDsn: undefined,
-  trackingId: '',
   redirectUrl: 'https://api.exilence.de/api/authentication/redirect',
   oauthUrl: 'https://www.pathofexile.com',
   pathOfExileUrl: 'https://www.pathofexile.com',

--- a/src/config/app.config.prod.ts
+++ b/src/config/app.config.prod.ts
@@ -2,7 +2,6 @@ const prodConfig = {
   baseUrl: 'https://api.exilence.de',
   production: true,
   sentryBrowserDsn: undefined,
-  trackingId: '',
   redirectUrl: 'https://api.exilence.de/api/authentication/redirect',
   oauthUrl: 'https://www.pathofexile.com',
   pathOfExileUrl: 'https://www.pathofexile.com',

--- a/src/config/sentry.ts
+++ b/src/config/sentry.ts
@@ -1,11 +1,13 @@
 import * as Sentry from '@sentry/browser';
 
 import AppConfig from './app.config';
+import { sanitizeSentryEvent } from '../utils/sentry.utils';
 
 function initSentry() {
   if (AppConfig.production) {
     Sentry.init({
       dsn: AppConfig.sentryBrowserDsn,
+      beforeSend: sanitizeSentryEvent,
       ignoreErrors: [
         'Request failed',
         'net::',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,6 @@ import React, { Suspense, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { HashRouter as Router, Redirect, Route } from 'react-router-dom';
 import 'react-toastify/dist/ReactToastify.min.css';
-import ua, { Visitor } from 'universal-analytics';
 import './assets/styles/reactour.scss';
 import exilenceTheme from './assets/themes/exilence-theme';
 import AnnouncementDialogContainer from './components/announcement-dialog/AnnouncementDialogContainer';
@@ -28,7 +27,6 @@ import Notifier from './components/notifier/Notifier';
 import ReactionContainer from './components/reaction-container/ReactionContainer';
 import ToastWrapper from './components/toast-wrapper/ToastWrapper';
 import ToolbarContainer from './components/toolbar/ToolbarContainer';
-import AppConfig from './config/app.config';
 import configureAxios from './config/axios';
 import configureI18n from './config/i18n';
 import initSentry from './config/sentry';
@@ -46,7 +44,6 @@ declare module '@mui/styles/defaultTheme' {
 }
 
 export const appName = 'Exilence CE';
-export let visitor: Visitor | undefined = undefined;
 initSentry();
 configureI18n();
 configureAxios();
@@ -169,7 +166,6 @@ const renderApp = () => {
           }
         }
       }
-      visitor = ua(AppConfig.trackingId, rootStore.uiStateStore.userId);
       ReactDOM.render(<App />, document.getElementById('root'));
     })
     .catch((err: Error) => {

--- a/src/routes/bulk-sell/BulkSell.tsx
+++ b/src/routes/bulk-sell/BulkSell.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { appName, useStores, visitor } from '../..';
+import { useStores } from '../..';
 import {
   Accordion,
   AccordionDetails,
@@ -35,7 +35,6 @@ const BulkSell = () => {
     if (!uiStateStore!.validated && !uiStateStore!.initiated && !uiStateStore!.isValidating) {
       accountStore!.validateSession('/bulk-sell');
     }
-    visitor!.pageview('/bulk-sell', appName).send();
     uiStateStore!.setBulkSellView(true);
   }, []);
 

--- a/src/routes/login/Login.tsx
+++ b/src/routes/login/Login.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { observer } from 'mobx-react-lite';
 
-import { appName, visitor } from '../..';
 import Image from '../../assets/img/scourge-bg.jpg';
 import LoginContentContainer from '../../components/login-content/LoginContentContainer';
 
@@ -16,10 +15,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 const Login = () => {
-  useEffect(() => {
-    visitor!.pageview('/login', appName).send();
-  });
-
   const classes = useStyles();
   return (
     <div className={classes.loginWrapper}>

--- a/src/routes/net-worth/NetWorth.tsx
+++ b/src/routes/net-worth/NetWorth.tsx
@@ -8,7 +8,7 @@ import { Box, Grid, Skeleton, Tooltip, Typography, useTheme } from '@mui/materia
 import { observer } from 'mobx-react-lite';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { appName, useStores, visitor } from '../..';
+import { useStores } from '../..';
 import { primaryLighter, rarityColors } from '../../assets/themes/exilence-theme';
 import ChartToolboxContainer from '../../components/chart-toolbox/ChartToolboxContainer';
 import {
@@ -93,7 +93,6 @@ const NetWorth = () => {
       accountStore!.validateSession('/net-worth');
     }
 
-    visitor!.pageview('/net-worth', appName).send();
     uiStateStore!.setBulkSellView(false);
   }, []);
 

--- a/src/routes/settings/Settings.tsx
+++ b/src/routes/settings/Settings.tsx
@@ -1,7 +1,7 @@
 import { Grid } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect } from 'react';
-import { appName, useStores, visitor } from '../..';
+import { useStores } from '../..';
 import FeatureWrapper from '../../components/feature-wrapper/FeatureWrapper';
 import SettingsTabs from '../../components/settings-tabs/SettingsTabs';
 
@@ -11,7 +11,6 @@ const Settings = () => {
     if (!uiStateStore!.validated && !uiStateStore!.initiated && !uiStateStore!.isValidating) {
       accountStore!.validateSession('/settings');
     }
-    visitor!.pageview('/settings', appName).send();
   }, []);
 
   return (

--- a/src/store/accountStore.ts
+++ b/src/store/accountStore.ts
@@ -31,8 +31,8 @@ export class AccountStore {
 
   constructor(private rootStore: RootStore) {
     makeObservable(this);
-    electronService.ipcRenderer.on('auth-callback', (_event, { code, error }) => {
-      this.handleAuthCallback(code, error);
+    electronService.ipcRenderer.on('auth-callback', (_event, { code, error, state }) => {
+      this.handleAuthCallback(code, error, state);
     });
 
     autorun(() => {
@@ -100,7 +100,12 @@ export class AccountStore {
   }
 
   @action
-  handleAuthCallback(code: string, error: string) {
+  handleAuthCallback(code: string, error: string, state?: string) {
+    if (state !== this.authState) {
+      this.loginWithOAuthFail(new Error('error:invalid_auth_state'));
+      return;
+    }
+
     // If there is a code, proceed to get token
     if (code) {
       this.setCode(code);
@@ -117,6 +122,7 @@ export class AccountStore {
 
   @action
   loadOAuthPage() {
+    this.authState = uuidv4();
     openCustomLink(this.authUrl);
   }
 
@@ -172,7 +178,7 @@ export class AccountStore {
   }
 
   @action
-  loginWithOAuthFail(e?: AxiosError) {
+  loginWithOAuthFail(e?: AxiosError | Error) {
     this.rootStore.notificationStore.createNotification('login_with_oauth', 'error', true, e);
     this.rootStore.routeStore.redirect('/login');
   }

--- a/src/store/domains/account.ts
+++ b/src/store/domains/account.ts
@@ -12,7 +12,7 @@ import { ICharacter } from '../../interfaces/character.interface';
 import { authService } from '../../services/auth.service';
 import { mapProfileToApiProfile } from '../../utils/profile.utils';
 import { genericRetryStrategy } from '../../utils/rxjs.utils';
-import { rootStore, visitor } from './../../index';
+import { rootStore } from './../../index';
 import { IProfile } from './../../interfaces/profile.interface';
 import { AccountLeague } from './account-league';
 import { Profile } from './profile';
@@ -285,8 +285,6 @@ export class Account implements IAccount {
   @action
   removeActiveProfile() {
     rootStore.uiStateStore.setRemovingProfile(true);
-    visitor!.event('Profile', 'Remove profile').send();
-
     const profileIndex = this.profiles.findIndex((p) => p.active);
     const newActiveProfile = this.profiles.find((p) => !p.active);
 

--- a/src/store/domains/profile.ts
+++ b/src/store/domains/profile.ts
@@ -41,7 +41,7 @@ import {
   getValueForSnapshotsTabs,
   mapSnapshotToApiSnapshot,
 } from '../../utils/snapshot.utils';
-import { rootStore, visitor } from './../../index';
+import { rootStore } from './../../index';
 import { externalService } from './../../services/external.service';
 import { Snapshot } from './snapshot';
 import { StashTabSnapshot } from './stashtab-snapshot';
@@ -329,8 +329,6 @@ export class Profile {
 
   @action
   updateProfile(profile: IProfile, callback: () => void) {
-    visitor!.event('Profile', 'Edit profile').send();
-
     const apiProfile = mapProfileToApiProfile(
       new Profile(profile),
       rootStore.settingStore.activeCurrency
@@ -367,8 +365,6 @@ export class Profile {
   }
 
   @action snapshot() {
-    visitor!.event('Profile', 'Triggered snapshot').send();
-
     rootStore.uiStateStore!.setIsSnapshotting(true);
     this.refreshStashTabs();
   }

--- a/src/utils/auth-callback.utils.test.ts
+++ b/src/utils/auth-callback.utils.test.ts
@@ -1,0 +1,33 @@
+import { getAuthCallbackPayload } from './auth-callback.utils';
+
+describe('getAuthCallbackPayload', () => {
+  it('parses code and state from a custom protocol callback', () => {
+    expect(getAuthCallbackPayload('exilence://auth?code=abc123&state=csrf-token')).toEqual({
+      code: 'abc123',
+      error: undefined,
+      state: 'csrf-token',
+    });
+  });
+
+  it('parses the callback URL from Windows second-instance arguments', () => {
+    expect(
+      getAuthCallbackPayload([
+        'C:\\Program Files\\Exilence CE\\Exilence CE.exe',
+        '--some-electron-flag',
+        'exilence://auth?code=abc123&state=csrf-token',
+      ])
+    ).toEqual({
+      code: 'abc123',
+      error: undefined,
+      state: 'csrf-token',
+    });
+  });
+
+  it('decodes authorization errors from fallback query parsing', () => {
+    expect(getAuthCallbackPayload('not-a-url ?error=access+denied&state=csrf-token')).toEqual({
+      code: undefined,
+      error: 'access denied',
+      state: 'csrf-token',
+    });
+  });
+});

--- a/src/utils/auth-callback.utils.ts
+++ b/src/utils/auth-callback.utils.ts
@@ -1,0 +1,35 @@
+export interface IAuthCallbackPayload {
+  code?: string;
+  error?: string;
+  state?: string;
+}
+
+export function getAuthCallbackPayload(deepLink: string | string[]): IAuthCallbackPayload {
+  const link = Array.isArray(deepLink)
+    ? deepLink.find((arg) => arg.includes('code=') || arg.includes('error=')) ?? deepLink.join(' ')
+    : deepLink;
+
+  return {
+    code: getDeepLinkParam(link, 'code'),
+    error: getDeepLinkParam(link, 'error'),
+    state: getDeepLinkParam(link, 'state'),
+  };
+}
+
+function getDeepLinkParam(link: string, name: string): string | undefined {
+  try {
+    return new URL(link).searchParams.get(name) ?? undefined;
+  } catch (_error) {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = new RegExp(`[?&]${escapedName}=([^&#]*)`).exec(link);
+    return match && match.length > 1 ? decodeParam(match[1]) : undefined;
+  }
+}
+
+function decodeParam(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, ' '));
+  } catch (_error) {
+    return value;
+  }
+}

--- a/src/utils/sentry.utils.test.ts
+++ b/src/utils/sentry.utils.test.ts
@@ -1,0 +1,52 @@
+import type { Event } from '@sentry/types';
+import { sanitizeSentryEvent } from './sentry.utils';
+
+describe('sanitizeSentryEvent', () => {
+  it('redacts auth headers, cookies, and OAuth query parameters', () => {
+    const event: Event = {
+      message: 'request failed https://api.exilence.de/oauth?code=secret-code&state=secret-state',
+      request: {
+        url: 'https://api.exilence.de/oauth?code=secret-code&state=secret-state&safe=1',
+        headers: {
+          Authorization: 'Bearer secret-token',
+          Cookie: 'POESESSID=secret-cookie',
+          Accept: 'application/json',
+        },
+        cookies: {
+          POESESSID: 'secret-cookie',
+        },
+        query_string: {
+          code: 'secret-code',
+          safe: '1',
+        },
+      },
+    };
+
+    expect(sanitizeSentryEvent(event)).toEqual({
+      message: 'request failed https://api.exilence.de/oauth?code=[Filtered]&state=[Filtered]',
+      request: {
+        url: 'https://api.exilence.de/oauth?code=%5BFiltered%5D&state=%5BFiltered%5D&safe=1',
+        headers: {
+          Authorization: '[Filtered]',
+          Cookie: '[Filtered]',
+          Accept: 'application/json',
+        },
+        cookies: undefined,
+        query_string: {
+          code: '[Filtered]',
+          safe: '1',
+        },
+      },
+    });
+  });
+
+  it('redacts bearer tokens from string request data', () => {
+    const event: Event = {
+      request: {
+        data: 'Authorization: Bearer secret-token',
+      },
+    };
+
+    expect(sanitizeSentryEvent(event).request!.data).toBe('Authorization: Bearer [Filtered]');
+  });
+});

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -1,0 +1,81 @@
+import type { Event } from '@sentry/types';
+
+const FILTERED = '[Filtered]';
+const SENSITIVE_HEADERS = ['authorization', 'cookie', 'set-cookie'];
+const SENSITIVE_QUERY_PARAMS = ['access_token', 'code', 'refresh_token', 'state', 'token'];
+
+export function sanitizeSentryEvent(event: Event): Event {
+  if (event.message) {
+    event.message = redactSensitiveValues(event.message);
+  }
+
+  if (event.request) {
+    event.request.url = redactUrl(event.request.url);
+
+    if (typeof event.request.data === 'string') {
+      event.request.data = redactSensitiveValues(event.request.data);
+    }
+
+    if (typeof event.request.query_string === 'string') {
+      event.request.query_string = redactSensitiveValues(event.request.query_string);
+    } else if (Array.isArray(event.request.query_string)) {
+      event.request.query_string = event.request.query_string.map(([key, value]): [
+        string,
+        string
+      ] => [key, isSensitiveQueryParam(key) ? FILTERED : redactSensitiveValues(value)]);
+    } else if (event.request.query_string) {
+      const queryString = event.request.query_string;
+      Object.keys(queryString).forEach((key) => {
+        queryString[key] = isSensitiveQueryParam(key)
+          ? FILTERED
+          : redactSensitiveValues(queryString[key]);
+      });
+    }
+
+    redactHeaders(event.request.headers);
+    event.request.cookies = undefined;
+  }
+
+  return event;
+}
+
+function redactHeaders(headers?: Record<string, string>): void {
+  if (!headers) {
+    return;
+  }
+
+  Object.keys(headers).forEach((header) => {
+    if (SENSITIVE_HEADERS.includes(header.toLowerCase())) {
+      headers[header] = FILTERED;
+    }
+  });
+}
+
+function redactUrl(url?: string): string | undefined {
+  if (!url) {
+    return url;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    SENSITIVE_QUERY_PARAMS.forEach((param) => {
+      if (parsedUrl.searchParams.has(param)) {
+        parsedUrl.searchParams.set(param, FILTERED);
+      }
+    });
+    return parsedUrl.toString();
+  } catch (_error) {
+    return redactSensitiveValues(url);
+  }
+}
+
+function redactSensitiveValues(value: string): string {
+  const withoutBearerToken = value.replace(/Bearer\s+[^,&\s]+/gi, `Bearer ${FILTERED}`);
+  return SENSITIVE_QUERY_PARAMS.reduce((current, param) => {
+    return current.replace(new RegExp(`([?&]${param}=)[^&#\\s,]+`, 'gi'), `$1${FILTERED}`);
+  }, withoutBearerToken);
+}
+
+function isSensitiveQueryParam(param: string): boolean {
+  return SENSITIVE_QUERY_PARAMS.includes(param.toLowerCase());
+}


### PR DESCRIPTION
﻿## Summary
- Remove the legacy `universal-analytics` dependency and all page/action tracking calls.
- Validate the OAuth callback `state` before exchanging an authorization code.
- Scrub OAuth codes, state values, bearer tokens, auth headers, and cookies from browser/main-process Sentry events.
- Add focused regression coverage for callback parsing and Sentry redaction.

## Root Cause
The app initialized Google Analytics without an in-app consent path and exported a shared visitor instance that routes and profile actions called directly. The OAuth callback parser only extracted `code`/`error`, so the app never compared callback state to the state it generated for the authorization request. Sentry also had no shared redaction hook for auth-bearing request metadata.

## Fix
- Removed `universal-analytics`, `@types/universal-analytics`, `trackingId`, and all visitor page/action calls.
- Added a typed callback parser that handles macOS `open-url` callbacks and Windows/Linux second-instance argv callbacks, including `state`.
- Regenerated OAuth state immediately before opening the authorization URL and rejected callbacks whose state does not match.
- Added a shared Sentry sanitizer and installed it for both renderer and Electron main-process Sentry clients.
- Kept the change mechanical: no UI redesign, no subjective changes, no backend/API policy claims.

## Validation
- `npm.cmd ci --no-audit --no-fund` passed.
- `node -e "JSON.parse(require('fs').readFileSync('package-lock.json','utf8')); console.log('package-lock json ok')"` passed.
- `$env:CI='true'; npx.cmd -y -p node@14 -p npm@7 npm run react-test -- --watchAll=false src/utils/auth-callback.utils.test.ts src/utils/sentry.utils.test.ts` passed: 2 suites, 5 tests.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- eslint electron/main.ts src/config/sentry.ts src/index.tsx src/routes/bulk-sell/BulkSell.tsx src/routes/login/Login.tsx src/routes/net-worth/NetWorth.tsx src/routes/settings/Settings.tsx src/store/accountStore.ts src/store/domains/account.ts src/store/domains/profile.ts src/utils/auth-callback.utils.ts src/utils/auth-callback.utils.test.ts src/utils/sentry.utils.ts src/utils/sentry.utils.test.ts` passed with the repo's existing React-version warning.
- `npx.cmd -y -p node@14 -p npm@7 npm run react-build` passed.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- tsc -p electron` passed.

## Risk / Rollback
Risk is concentrated in OAuth callback handling: if the upstream redirect endpoint ever omits `state`, login now fails closed instead of exchanging the code. That is intentional for CSRF safety, but rollback is straightforward: revert the state validation commit or relax the check after confirming server behavior. Analytics removal is low-risk and rollback would be reinstalling the removed dependency plus restoring the visitor calls.

Fixes #23
Refs #4
Refs #6
Refs #13
