### PR TITLE
Fetch selected child stash tabs correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+#### Fixed
+- Fetch selected child stash tabs with their parent tab path so folder/map subtabs are not silently skipped during snapshots.
+
 ## [1.2.11] - 2025-02-21
 #### Added
 - Added support for Beasts, new Map Variants & Kaluuran Runes (thank you Mrjamy <3)

--- a/src/services/external.service.ts
+++ b/src/services/external.service.ts
@@ -9,6 +9,7 @@ import { IGithubRelease } from '../interfaces/github/github-release.interface';
 import { ILeague } from '../interfaces/league.interface';
 import { IPoeProfile } from '../interfaces/poe-profile.interface';
 import { IStash, IStashTab, IStashTabResponse } from '../interfaces/stash.interface';
+import { getRequestedStashTab, getStashTabRequestId } from '../utils/stash-tab.utils';
 import AppConfig from './../config/app.config';
 const apiUrl = AppConfig.pathOfExileApiUrl;
 
@@ -54,8 +55,7 @@ function getStashTabWithChildren(
   let innerLimiter;
   let outerLimiter;
   const makeRequest = (tab: IStashTab) => {
-    const prefix = tab.parent && children ? `${tab.parent}/` : '';
-    return getStashTab(league, `${prefix}${tab.id}`).pipe(
+    return getStashTab(league, getStashTabRequestId(tab)).pipe(
       map((stashTab: AxiosResponse<IStashTabResponse>) => {
         if (!children) {
           rootStore.uiStateStore.incrementStatusMessageCount();
@@ -81,7 +81,7 @@ function getStashTabWithChildren(
         rootStore.rateLimitStore.setLastRequestTimestamp(new Date());
         rootStore.rateLimitStore.setLastRateLimitState(state);
         rootStore.rateLimitStore.setLastRateLimitBoundaries(limits);
-        return { stash: stashTab.data.stash, limits, state };
+        return { stash: getRequestedStashTab(stashTab.data.stash, tab), limits, state };
       }),
       delay(125)
     );

--- a/src/utils/stash-tab.utils.test.ts
+++ b/src/utils/stash-tab.utils.test.ts
@@ -1,0 +1,39 @@
+import { IStashTab } from '../interfaces/stash.interface';
+import { getRequestedStashTab, getStashTabRequestId } from './stash-tab.utils';
+
+const createStashTab = (id: string, parent?: string): IStashTab => ({
+  id,
+  parent,
+  index: 0,
+  name: 'Dump',
+  type: 'PremiumStash',
+  metadata: {},
+});
+
+describe('getStashTabRequestId', () => {
+  it('uses the tab id for top-level stash tabs', () => {
+    expect(getStashTabRequestId(createStashTab('aaaa1111'))).toBe('aaaa1111');
+  });
+
+  it('uses the documented parent/substash path for child stash tabs', () => {
+    expect(getStashTabRequestId(createStashTab('bbbb2222', 'aaaa1111'))).toBe('aaaa1111/bbbb2222');
+  });
+});
+
+describe('getRequestedStashTab', () => {
+  it('returns top-level stash responses unchanged', () => {
+    const stashTab = createStashTab('aaaa1111');
+
+    expect(getRequestedStashTab(stashTab, stashTab)).toEqual(stashTab);
+  });
+
+  it('unwraps child stash tabs from parent-wrapped API responses', () => {
+    const requestedChild = createStashTab('bbbb2222', 'aaaa1111');
+    const parentResponse = {
+      ...createStashTab('aaaa1111'),
+      children: [requestedChild],
+    };
+
+    expect(getRequestedStashTab(parentResponse, requestedChild)).toEqual(requestedChild);
+  });
+});

--- a/src/utils/stash-tab.utils.ts
+++ b/src/utils/stash-tab.utils.ts
@@ -1,0 +1,19 @@
+import { IStashTab } from '../interfaces/stash.interface';
+
+export function getStashTabRequestId(stashTab: IStashTab): string {
+  return stashTab.parent ? `${stashTab.parent}/${stashTab.id}` : stashTab.id;
+}
+
+export function getRequestedStashTab(
+  responseStashTab: IStashTab,
+  requestedStashTab: IStashTab
+): IStashTab {
+  if (!requestedStashTab.parent || responseStashTab.id !== requestedStashTab.parent) {
+    return responseStashTab;
+  }
+
+  return (
+    responseStashTab.children?.find((child) => child.id === requestedStashTab.id) ??
+    responseStashTab
+  );
+}


### PR DESCRIPTION
﻿## Summary
- Fetch selected child stash tabs using the documented parent/substash path.
- Normalize parent-wrapped child stash responses back to the requested child tab before snapshot pricing.
- Add focused unit coverage for top-level tabs, child-tab request IDs, and parent-wrapped child responses.

## Root Cause
The Path of Exile stash endpoint supports child tabs as `GET /stash/<league>/<stash_id>/<substash_id>`, where the child id is scoped under the parent tab. The client only prefixed the parent id when recursively fetching subtabs, not when a child tab was directly selected for snapshot content or used to prime rate-limit headers. That could make selected folder/map subtabs appear empty, missing, or skipped even though the profile selection was valid.

Reference: https://www.pathofexile.com/developer/docs/reference#account-stashes

## Fix
- Added `getStashTabRequestId` so every child stash request consistently uses `parent/id`.
- Added `getRequestedStashTab` so a parent-wrapped API response is unwrapped to the requested child tab before later snapshot code maps items.
- Reused the helper in `externalService.getStashTabWithChildren` instead of keeping path construction inline.
- Kept the change narrow: no new UI, no changes to profile selection behavior, no additional requests beyond the intended selected tab fetch.

## Validation
- `npm.cmd ci --no-audit --no-fund` passed.
- `$env:CI='true'; npx.cmd -y -p node@14 -p npm@7 npm run react-test -- --watchAll=false src/utils/stash-tab.utils.test.ts` passed: 1 suite, 4 tests.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- eslint src/services/external.service.ts src/utils/stash-tab.utils.ts src/utils/stash-tab.utils.test.ts` passed with the repo's existing React-version warning.
- `npx.cmd -y -p node@14 -p npm@7 npm run react-build` passed.
- `npx.cmd -y -p node@14 -p npm@7 npm exec -- tsc -p electron` passed.

## Risk / Rollback
Risk is low and localized to stash content fetch path construction. Top-level stash tabs keep the same id. Child tabs now use the documented parent/substash path and are unwrapped defensively if the API returns the parent container. Rollback is a single commit revert if any legacy stash response shape depends on the old direct-child path.

Refs #26
Refs #34
Refs #35
